### PR TITLE
Fix visualisation with client-side changes

### DIFF
--- a/html/js/mqtt_client.js
+++ b/html/js/mqtt_client.js
@@ -197,7 +197,7 @@ function handleTrafficMessage(data) {
         var to_node = f['to'];
 
         if (from_node != null && to_node != null) {
-            addFlow(timestamp, from_node, to_node, f['count'], f['size']);
+            addFlow(timestamp + time_sync, from_node, to_node, f['count'], f['size']);
         } else {
             console.log("partial message: " + JSON.stringify(data))
         }

--- a/html/js/mqtt_client.js
+++ b/html/js/mqtt_client.js
@@ -1,5 +1,6 @@
 var client = new Paho.MQTT.Client("192.168.8.1", 1884, "clientId");
 //var client = new Paho.MQTT.Client("127.0.0.1", 1884, "clientId");
+var last_traffic = new Date(0) // Last received traffic trace
 
 function init() {
     initGraphs();
@@ -10,6 +11,9 @@ function init() {
 
     // connect the client
     client.connect({onSuccess:onTrafficOpen});
+
+    // Make smooth traffic graph when no data is received
+    setInterval(fillEmptiness, 1000);
 }
 
 // called when a message arrives
@@ -128,9 +132,18 @@ function initTrafficDataView() {
     handleTrafficMessage(data);
 }
 
+// Sometimes, no data is received for some time
+// Fill that void by adding 0-value datapoints to the graph
+function fillEmptiness() {
+    if ((new Date()) - last_traffic > 1000) {
+        initTrafficDataView(); // Abuse init function
+    }
+}
+
 // other code goes here
 // Update the Graphs (traffic graph and network view)
 function handleTrafficMessage(data) {
+    last_traffic = Date.now() // update to report new traffic
 
     var timestamp = data['timestamp']
 

--- a/html/js/mqtt_client.js
+++ b/html/js/mqtt_client.js
@@ -2,6 +2,7 @@ var client = new Paho.MQTT.Client("192.168.8.1", 1884, "clientId");
 //var client = new Paho.MQTT.Client("127.0.0.1", 1884, "clientId");
 var last_traffic = 0 // Last received traffic trace
 var time_sync = 0; // Time difference (seconds) between server and client
+var active = false; // Determines whether we are active or not
 
 function init() {
     initGraphs();
@@ -115,6 +116,7 @@ function onTrafficOpen(evt) {
     sendCommand("get_alloweds", {})//, "")
     //show connected status somewhere
     $("#statustext").css("background-color", "#ccffcc").text("Connected");
+    active = true;
 }
 
 function onTrafficClose(evt) {
@@ -122,6 +124,7 @@ function onTrafficClose(evt) {
     $("#statustext").css("background-color", "#ffcccc").text("Not connected");
     console.log('Websocket has disappeared');
     console.log(evt.errorMessage)
+    active = false;
 }
 
 function onTrafficError(evt) {
@@ -139,7 +142,7 @@ function initTrafficDataView() {
 // Sometimes, no data is received for some time
 // Fill that void by adding 0-value datapoints to the graph
 function fillEmptiness() {
-    if (last_traffic != 0 && Date.now() - last_traffic >= 1000) {
+    if (active && last_traffic != 0 && Date.now() - last_traffic >= 1000) {
         var data = { 'timestamp': Math.floor(Date.now() / 1000) - time_sync,
                      'total_size': 0, 'total_count': 0,
                      'flows': []}


### PR DESCRIPTION
Fixes #12 and #15.
Basically, this patch implements automatically padding the dataset in the client's browser with 0-data, but only when no data has been received for at least a second.
Furthermore, it adds support for timing differences between the SPIN device and the browser.