### PR TITLE
Allow multiple clients to access SPIN graph

### DIFF
--- a/html/js/mqtt_client.js
+++ b/html/js/mqtt_client.js
@@ -1,4 +1,4 @@
-var client = new Paho.MQTT.Client("valibox.", 1884, Math.random().toString(16).slice(-5));
+var client = new Paho.MQTT.Client("valibox.", 1884, "Web-" + Math.random().toString(16).slice(-5));
 //var client = new Paho.MQTT.Client("127.0.0.1", 1884, "clientId");
 
 function init() {

--- a/html/js/mqtt_client.js
+++ b/html/js/mqtt_client.js
@@ -1,4 +1,4 @@
-var client = new Paho.MQTT.Client("192.168.8.1", 1884, "clientId");
+var client = new Paho.MQTT.Client("valibox.", 1884, Math.random().toString(16).slice(-5));
 //var client = new Paho.MQTT.Client("127.0.0.1", 1884, "clientId");
 
 function init() {


### PR DESCRIPTION
By default, only a single webclient can show the graphs. This quick fix allows multiple clients by adding a pseudo-random uid as client identifier for the mqtt connection.

Furthermore, we use the DNS name for the valibox instead of a fixed ip address.