### PR TITLE
Fix node colors in visualisation with DNS queries

### DIFF
--- a/html/js/spingraphs.js
+++ b/html/js/spingraphs.js
@@ -835,6 +835,10 @@ function addEdge(from, to, colour) {
             color: colour
         });
         curEdgeId += 1;
+    } else if (existing[0].color != colour) {
+        // If color changed, update it!
+        existing[0].color = colour;
+        edges.update(existing[0]);
     }
 }
 

--- a/html/js/spingraphs.js
+++ b/html/js/spingraphs.js
@@ -761,10 +761,13 @@ function addNode(timestamp, node, scale, count, size, lwith, type) {
         colour = colour_src;
     } else {
         if (blocked) {
+            // Node observes blocked traffic
             colour = colour_blocked;
-        } else if (dnsquery) {
+        } else if (dnsquery && !nodes.get(node.id)) {
+            // Node does not exist, dnsquery
             colour = colour_dns;
         } else {
+            // In all other cases
             colour = colour_recent;
         }
     }


### PR DESCRIPTION
Implements two fixes:
1. Fixes #31: DNS would override node colors. 
2. Fixes #29: arrows now get updated to reflect latest received dataflow. 