### PR TITLE
spind_conntrack.c: handle error case properly

### DIFF
--- a/src/spind_conntrack.c
+++ b/src/spind_conntrack.c
@@ -408,6 +408,7 @@ handle_dns(const u_char *bp, u_int length, long long timestamp)
     ips = calloc(ips_len, sizeof(char *));
     if (!ips) {
         fprintf(stderr, "calloc");
+        goto out;
     }
 
     query = ldns_rdf2str(ldns_rr_owner(ldns_rr_list_rr(ldns_pkt_question(p),


### PR DESCRIPTION
In the original code, this error was handled by calling err(3). err(3)
prints a message and then exits. When the call to err(3) is replaced
with a call to fprintf(3), we have to make sure we do not continue
executing the normal code path.