### PR TITLE
core2nfq_dns.c: properly initialize variable

### DIFF
--- a/src/spind/core2nfq_dns.c
+++ b/src/spind/core2nfq_dns.c
@@ -77,7 +77,7 @@ handle_dns_answer(const u_char *bp, u_int length, long long timestamp, int proto
 {
     ldns_status status;
     ldns_pkt *p = NULL;
-    ldns_rr_list *answers;
+    ldns_rr_list *answers = NULL;
     ldns_rr *rr;
     ldns_rdf *rdf;
     size_t count;


### PR DESCRIPTION
Otherwise bad things will happen if we "goto out" before `answers' is
assigned to.