### PR TITLE
core2pubsub.c: more robust error handling in wf_mosquitto()

### DIFF
--- a/src/spind/core2pubsub.c
+++ b/src/spind/core2pubsub.c
@@ -372,17 +372,31 @@ void connect_mosquitto(const char* host, int port) {
 }
 
 void wf_mosquitto(void* arg, int data, int timeout) {
+    int result;
+
     STAT_COUNTER(ctr_data, wf-data, STAT_TOTAL);
     STAT_COUNTER(ctr_timeout, wf-timeout, STAT_TOTAL);
 
     if (data) {
         STAT_VALUE(ctr_data, 1);
-        mosquitto_loop_read(mosq, 1);
+        result = mosquitto_loop_read(mosq, 1);
+        if (result != 0) {
+            spin_log(LOG_ERR, "Error calling mosquitto_loop_read(): %s\n", mosquitto_strerror(result));
+            exit(1);
+        }
     }
     if (timeout) {
         STAT_VALUE(ctr_timeout, 1);
-        mosquitto_loop_write(mosq, 1);
-        mosquitto_loop_misc(mosq);
+        result = mosquitto_loop_write(mosq, 1);
+        if (result != 0) {
+            spin_log(LOG_ERR, "Error calling mosquitto_loop_write(): %s\n", mosquitto_strerror(result));
+            exit(1);
+        }
+        result = mosquitto_loop_misc(mosq);
+        if (result != 0) {
+            spin_log(LOG_ERR, "Error calling mosquitto_loop_misc(): %s\n", mosquitto_strerror(result));
+            exit(1);
+        }
     }
 }
 


### PR DESCRIPTION
This one may be a bit more controversial than #57. We may not want to terminate if an error occurs here but try to recover instead (e.g. by reconnecting on failure). But this is better than just carrying on. I only compile-tested this.