### PR TITLE
buffer_writev(): a va_list cannot be reused

### DIFF
--- a/src/lib/tests/util_test.c
+++ b/src/lib/tests/util_test.c
@@ -154,6 +154,28 @@ test_buffer_resize() {
     buffer_destroy(buf);
 }
 
+void
+test_buffer_va_list() {
+    const char *fmt = "%s, %s";
+    const char *a = "123456";
+    const char *b = "abcdef";
+    char check[16];
+
+    buffer_t* buf = buffer_create(8);
+    buffer_allow_resize(buf);
+
+    buffer_write(buf, fmt, a, b);
+
+    assert(buf->max == 16);
+    assert(buffer_ok(buf));
+    buffer_finish(buf);
+
+    sprintf(check, fmt, a, b);
+    check_bufstr(buf, check);
+
+    buffer_destroy(buf);
+}
+
 // note; if this test fails it may leave a tmp file around
 void
 test_ip_tree_read_write() {
@@ -204,6 +226,7 @@ int main(int argc, char** argv) {
     test_buffer_write_1();
     test_buffer_write_2();
     test_buffer_resize();
+    test_buffer_va_list();
     test_ip_tree_read_write();
     return 0;
 }

--- a/src/lib/util.c
+++ b/src/lib/util.c
@@ -185,7 +185,9 @@ void buffer_resize(buffer_t* buffer) {
 int
 buffer_writev(buffer_t* buffer, const char* format, va_list args) {
     int written = 0;
+    int result;
     size_t remaining;
+    va_list args_copy;
 
     if (!buffer->ok || buffer->finished) {
         return -1;
@@ -194,20 +196,32 @@ buffer_writev(buffer_t* buffer, const char* format, va_list args) {
     if (buffer->max < buffer->pos) {
         return -1;
     }
+
+    // A va_list cannot be reused so make a copy now in case we need it. We
+    // will need it when we have to resize the buffer after a failed call to
+    // vsnprintf(3).
+    va_copy(args_copy, args);
+
     remaining = buffer->max - buffer->pos;
     written = vsnprintf(buffer->data + buffer->pos, remaining, format, args);
     if (written == -1 || written+buffer->pos >= buffer->max) {
         if (buffer->allow_resize) {
             buffer_resize(buffer);
-            return buffer_writev(buffer, format, args);
+            result = buffer_writev(buffer, format, args_copy);
+            goto out;
         } else {
             buffer->ok = 0;
-            return -1;
+            result = -1;
+            goto out;
         }
     } else {
         buffer->pos += written;
     }
-    return 0;
+    result = 0;
+
+out:
+    va_end(args_copy);
+    return result;
 }
 
 int buffer_write(buffer_t* buffer, const char* format, ...) {


### PR DESCRIPTION
so make a copy before calling vsnprintf(3) since that function will use
the va_list.