### PR TITLE
tree_add(): only balance current->parent->right when appropriate

### DIFF
--- a/src/lib/tree.c
+++ b/src/lib/tree.c
@@ -94,7 +94,7 @@ int tree_add(tree_t* tree, size_t key_size, void* key, size_t data_size, void* d
                 while (current->parent != NULL) {
                     if (current->parent->left == current) {
                         current->parent->left = tree_entry_balance(current);
-                    } else {
+                    } else if (current->parent->right == current) {
                         current->parent->right = tree_entry_balance(current);
                     }
                     current = current->parent;
@@ -112,7 +112,7 @@ int tree_add(tree_t* tree, size_t key_size, void* key, size_t data_size, void* d
                 while (current->parent != NULL) {
                     if (current->parent->left == current) {
                         current->parent->left = tree_entry_balance(current);
-                    } else {
+                    } else if (current->parent->right == current) {
                         current->parent->right = tree_entry_balance(current);
                     }
                     current = current->parent;


### PR DESCRIPTION
I would appreciate some review on this one. I ran into problems because tree_entry_depth() kept calling itself recursively because current->left == current. This patch fixes this particular problem and I think the diff makes sense but I would like someone to double-check.