### PR TITLE
spind.c: remove -e command line argument

### DIFF
--- a/src/spind/spind.c
+++ b/src/spind/spind.c
@@ -28,7 +28,6 @@ static int local_mode;
 
 const char* mosq_host;
 int mosq_port;
-int stop_on_error;
 
 STAT_MODULE(spind)
 
@@ -309,15 +308,11 @@ int main(int argc, char** argv) {
     mosq_port = spinconfig_pubsub_port();
 
     printf("[XX] mosq host: %s\n", mosq_host);
-    stop_on_error = 0;
 
-    while ((c = getopt (argc, argv, "dehlm:op:v")) != -1) {
+    while ((c = getopt (argc, argv, "dhlm:op:v")) != -1) {
         switch (c) {
         case 'd':
             log_verbosity = 7;
-            break;
-        case 'e':
-            stop_on_error = 1;
             break;
         case 'h':
             print_help();


### PR DESCRIPTION
`stop_on_error` is set but never used anywhere. Do we still plan to use that variable/flag or can we remove it?

The reason I care about this is because I'm planning to use the `-e` flag for something else.